### PR TITLE
Update wrangler.toml

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -8,5 +8,6 @@ zone_id = ""
 
 [build]
 command = "npm install && npm run build"
-upload.format = "modules"
-upload.main = "./shim.mjs"
+[build.upload]
+format = "modules"
+main = "./shim.mjs"


### PR DESCRIPTION
toml_edit (used by wrangler generate) doesn't support dotted table syntax, we need to always use the full table syntax in templates